### PR TITLE
Update the CDC monolingual profiles to version 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - *Fixed (for any bug fixes)*
 - *Security (in case of vulnerabilities)*
 
+## [1.1.1]
+
+### Changed
+
+- Update the links of the CDC monolingual profiles to version 1.0.5
+
 ## [1.1.0]
 
 ### Changed
@@ -50,6 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved cmv docs from [cessda.cmv](https://github.com/cessda/cessda.cmv)
   to [cessda.cmv.documentation](https://github.com/cessda/cessda.cmv.documentation)
 
+[1.1.1]: https://github.com/cessda/cessda.cmv.documentation/releases/tag/1.1.1
 [1.1.0]: https://github.com/cessda/cessda.cmv.documentation/releases/tag/1.1.0
 [1.0.0]: https://github.com/cessda/cessda.cmv.documentation/releases/tag/v1.0.0
 [0.4.1]: https://github.com/cessda/cessda.cmv.documentation/releases/tag/v0.4.1

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # CESSDA Documentation Template
 ---
 # If you make changes here, you need to restart Jekyll to apply them
-title: "CESSDA Metadata Validator Documentation 1.0.1"
+title: "CESSDA Metadata Validator Documentation"
 baseurl: /documentation/
 destination: ./_site/documentation/
 

--- a/profiles.md
+++ b/profiles.md
@@ -13,12 +13,12 @@ nav_order: 030
 ### DDI 1.2.2
 
 - Profile version 1.0.4 <a href="/profiles/cdc/ddi-1.2.2/1.0.4/profile.xml" download>XML</a>/[HTML](/profiles/cdc/ddi-1.2.2/1.0.4/profile.html)
-- Profile version 1.0.4 - monolingual <a href="/profiles/cdc/ddi-1.2.2/1.0.4/profile-mono.xml" download>XML</a>/[HTML](/profiles/cdc/ddi-1.2.2/1.0.4/profile-mono.html)
+- Profile version 1.0.5 - monolingual <a href="/profiles/cdc/ddi-1.2.2/1.0.5/profile-mono.xml" download>XML</a>/[HTML](/profiles/cdc/ddi-1.2.2/1.0.5/profile-mono.html)
 
 ### DDI 2.5
 
 - Profile version 1.0.4 <a href="/profiles/cdc/ddi-2.5/1.0.4/profile.xml" download>XML</a>/[HTML](/profiles/cdc/ddi-2.5/1.0.4/profile.html)
-- Profile version 1.0.4 - monolingual <a href="/profiles/cdc/ddi-2.5/1.0.4/profile-mono.xml" download>XML</a>/[HTML](/profiles/cdc/ddi-2.5/1.0.4/profile-mono.html)
+- Profile version 1.0.5 - monolingual <a href="/profiles/cdc/ddi-2.5/1.0.5/profile-mono.xml" download>XML</a>/[HTML](/profiles/cdc/ddi-2.5/1.0.5/profile-mono.html)
 
 ### DDI 3.2
 


### PR DESCRIPTION
This is related to https://github.com/cessda/cessda.cmv.server/issues/126.